### PR TITLE
Fix EVAST's Discord server link

### DIFF
--- a/content/posts/bosu/index.md
+++ b/content/posts/bosu/index.md
@@ -16,7 +16,7 @@ summary: "A custom game mode for osu!lazer project based on &rdquo;I wanna be th
 - Creator : [Evast](https://github.com/EVAST9919)
 - Availability : Available Publicly
 - GitHub Repositories : [EVAST9919/bosu](https://github.com/EVAST9919/bosu)
-- Discord : [Evast's Server](https://discord.com/invite/7Y8GXAa)
+- Discord : [Evast's Server](https://discord.com/invite/HQgy3Ey)
 - Support : [Patreon](https://patreon.com/evast)
 
 Tau is a custom ruleset based on [I Wanna Be the Boshy](https://grynsoft.com/old-games#:~:text=I%20Wanna%20Be%20The%20Boshy%20(2010)) game. The ruleset is developed by Evast.

--- a/content/posts/sandbox/index.md
+++ b/content/posts/sandbox/index.md
@@ -15,10 +15,12 @@ summary: "A ruleset that make fun with osu!framework."
 # overview
 
 - Creator : [Evast](https://github.com/EVAST9919)
-- Availability : Available to Evast's supporter on Patreon
-- Patreon : [EVAST](https://www.patreon.com/evast/posts)
+- Availability : Available Publicly
+- GitHub Repositories : [EVAST9919/lazer-sandbox](https://github.com/EVAST9919/lazer-sandbox)
+- Discord : [Evast's Server](https://discord.com/invite/HQgy3Ey)
+- Support : [Patreon](https://patreon.com/evast)
 
-Sandbox is a playground dedicated to having fun with osu!framework inside osu!lazer. The ruleset is developed by Evast and is only available at Evast's Patreon page.
+Sandbox is a playground dedicated to having fun with osu!framework inside osu!lazer.
 
 # gameplay
 

--- a/content/posts/swing/index.md
+++ b/content/posts/swing/index.md
@@ -16,7 +16,7 @@ summary: "A custom game mode for osu!lazer project."
 - Creator : [Evast](https://github.com/EVAST9919)
 - Availability : Available Publicly
 - GitHub Repositories : [EVAST9919/lazer-swing](https://github.com/EVAST9919/lazer-swing)
-- Discord : [Evast's Server](https://discord.com/invite/7Y8GXAa)
+- Discord : [Evast's Server](https://discord.com/invite/HQgy3Ey)
 - Support : [Patreon](https://patreon.com/evast)
 
 Swing is a custom ruleset developed by Evast.

--- a/content/posts/touhosu/index.md
+++ b/content/posts/touhosu/index.md
@@ -16,7 +16,7 @@ summary: "A custom osu! ruleset based on Touhou Project games."
 - Creator : [Evast](https://github.com/EVAST9919)
 - Availability : Available Publicly
 - GitHub Repositories : [EVAST9919/touhosu](https://github.com/EVAST9919/touhosu)
-- Discord : [Evast's Server](https://discord.com/invite/7Y8GXAa)
+- Discord : [Evast's Server](https://discord.com/invite/HQgy3Ey)
 - Support : [Patreon](https://patreon.com/evast)
 
 Touhosu is a custom osu! ruleset based on [Touhou Project games](https://en.wikipedia.org/wiki/Touhou_Project#Games). The ruleset is developed by Evast and is only available at Evast's Patreon page

--- a/removed/mvis/index.md
+++ b/removed/mvis/index.md
@@ -16,7 +16,7 @@ summary: "A custom visual game mode for osu!lazer project."
 - Creator : [Evast](https://github.com/EVAST9919)
 - Availability : Available Publicly
 - GitHub Repositories : [EVAST9919/lazer-m-vis](https://github.com/EVAST9919/lazer-m-vis/)
-- Discord : [Evast's Server](https://discord.com/invite/7Y8GXAa)
+- Discord : [Evast's Server](https://discord.com/invite/HQgy3Ey)
 - Support : [Patreon](https://patreon.com/evast)
 
 Mvis is a custom ruleset for music visualizer. The ruleset is developed by Evast.


### PR DESCRIPTION
For some reason all of EVAST's Discord server links lead to Tau's Discord server. Here's the actual Discord link, based on the README from [EVAST9919/lazer-sandbox](https://github.com/EVAST9919/lazer-sandbox). Also, Sandbox is publicly available, it's not limited to EVAST's patrons.