### PR TITLE
Adjust and add animation on some page

### DIFF
--- a/rurusetto/users/templates/users/profile.html
+++ b/rurusetto/users/templates/users/profile.html
@@ -46,13 +46,13 @@
 
 {% if created_ruleset %}
 <div class="container">
-    <div class="row-mb-3" data-aos="fade-up" data-aos-duration="900">
+    <div class="row-mb-3" data-aos="fade-up" data-aos-duration="700" data-aos-once="true">
         <h1>created rulesets <span class="badge rounded-pill bg-rurusetto round-font-bold ">{{ created_ruleset| length }}</span></h1>
     </div>
     <div class="row-mb-3">
         <div class="row text-center gy-4">
             {% for detail in created_ruleset %}
-            <div class="col-lg-4" data-aos="fade-up" data-aos-duration="900">
+            <div class="col-lg-4" data-aos="fade-up" data-aos-duration="800" data-aos-once="true">
             <img src="{{ detail.0.icon.url }}" alt="{{ detail.0.name }}" width="140px" height="140px" class="rounded-circle">
 
             <h2 class="rulesets-name">{{ detail.0.name }}</h2>

--- a/rurusetto/wiki/templates/wiki/create_ruleset.html
+++ b/rurusetto/wiki/templates/wiki/create_ruleset.html
@@ -6,8 +6,8 @@
     <div class="container align-middle">
         <div class="row">
             <p></p>
-            <div><h1 class="display-5 fw-bold">Add a new ruleset</h1></div>
-            <p id="hero-description">Let's add a new ruleset! Is it yours? Don't worry! You can add it although you don't make that ruleset.</p>
+            <div data-aos="fade-up" data-aos-duration="600"><h1 class="display-5 fw-bold">Add a new ruleset</h1></div>
+            <p data-aos="fade-up" data-aos-duration=700" id="hero-description">Let's add a new ruleset! Is it yours? Don't worry! You can add it although you don't make that ruleset.</p>
         </div>
     </div>
 </div>

--- a/rurusetto/wiki/templates/wiki/listing.html
+++ b/rurusetto/wiki/templates/wiki/listing.html
@@ -43,7 +43,7 @@
       {% endif %}
     <div class="row text-center gy-4">
         {% for detail in rulesets %}
-        <div class="col-lg-4" data-aos="fade-up" data-aos-duration="900">
+        <div class="col-lg-4">
             <img src="{{ detail.0.icon.url }}" alt="{{ detail.0.name }}" width="140px" height="140px" class="rounded-circle">
 
             <h2 class="rulesets-name">{{ detail.0.name }}</h2>

--- a/rurusetto/wiki/templates/wiki/listing.html
+++ b/rurusetto/wiki/templates/wiki/listing.html
@@ -43,7 +43,7 @@
       {% endif %}
     <div class="row text-center gy-4">
         {% for detail in rulesets %}
-        <div class="col-lg-4">
+        <div class="col-lg-4" data-aos="fade-up" data-aos-duration="600" data-aos-once="true">
             <img src="{{ detail.0.icon.url }}" alt="{{ detail.0.name }}" width="140px" height="140px" class="rounded-circle">
 
             <h2 class="rulesets-name">{{ detail.0.name }}</h2>

--- a/rurusetto/wiki/templates/wiki/recommend_beatmap.html
+++ b/rurusetto/wiki/templates/wiki/recommend_beatmap.html
@@ -17,7 +17,7 @@
     <div class="row">
         {% if user.is_authenticated %}
         <div class="col-sm-4 hvr-icon-bounce">
-            <p data-aos="fade-up" data-aos-duration="800"><a class="text-decoration-none text-center spacing-hover-short" href="{% url 'add_recommend_beatmap' ruleset.slug %}"><i class="fas fa-plus icon-menu hvr-icon"></i> Add your recommend beatmaps</a></p>
+            <p data-aos="fade-up" data-aos-duration="700"><a class="text-decoration-none text-center spacing-hover-short" href="{% url 'add_recommend_beatmap' ruleset.slug %}"><i class="fas fa-plus icon-menu hvr-icon"></i> Add your recommend beatmaps</a></p>
         </div>
         {% else %}
             <p></p>
@@ -43,7 +43,7 @@
               {% endif %}
         </div>
     {% if beatmap_owner %}
-    <h1 data-aos="fade-up" data-aos-duration="700">Recommend by {{ ruleset.name }} creator</h1>
+    <h1 data-aos="fade-up" data-aos-duration="500">Recommend by {{ ruleset.name }} creator</h1>
     <div class="row">
         {% for beatmap in beatmap_owner %}
         {% include "wiki/snippets/beatmap_card.html" %}
@@ -52,7 +52,7 @@
     {% endif %}
 
     {% if beatmap_other %}
-    <h1 data-aos="fade-up" data-aos-duration="700">Recommend by other player</h1>
+    <h1 data-aos="fade-up" data-aos-duration="500">Recommend by other player</h1>
     <div class="row">
         {% for beatmap in beatmap_other %}
         {% include "wiki/snippets/beatmap_card.html" %}
@@ -60,7 +60,7 @@
     </div>
     {% endif %}
     {% if no_beatmap %}
-    <div data-aos="fade-up" data-aos-duration="700">
+    <div data-aos="fade-up" data-aos-duration="500">
         <h1 class="text-center">\ (•◡•) /</h1>
         <h3 class="text-center">No recommend beatmaps added in this rulesets.</h3>
         <h3 class="text-center">Let's add it first!</h3>

--- a/rurusetto/wiki/templates/wiki/snippets/beatmap_card.html
+++ b/rurusetto/wiki/templates/wiki/snippets/beatmap_card.html
@@ -1,6 +1,6 @@
 {% load convert_star_rating %}
 
-<div class="col-sm-6" data-aos="fade-up" data-aos-duration="700">
+<div class="col-sm-6" data-aos="fade-up" data-aos-duration="600" data-aos-once="true">
     <div class="card mb-3" style="max-width: 100%">
       <div class="row g-0 rounded" style="background-image: url({{ beatmap.0.beatmap_cover.url }}); background-size: cover; background-position: center">
         <div class="col-md-4">


### PR DESCRIPTION
After testing on new animation on scroll and after talk to user I decide to adjust animation on some page.

- listing: Adjust animation duration and set animation on listing to play only once.
- create ruleset form: Add animation to header (like other page)
- recommend beatmaps: Adjust animation duration and set animation on listing to play only once.
- profile page: Adjust animation duration and set animation on listing to play only once.