### PR TITLE
Add mobile view support for profile view and edit some ratio of profile page and global cover image settings.

### DIFF
--- a/rurusetto/users/static/css/index.css
+++ b/rurusetto/users/static/css/index.css
@@ -537,6 +537,22 @@ button.accordion-button:focus {
     color: #ff66aa;
 }
 
+@media (max-width: 1009px) {
+    #profile-pic {
+        flex: 0 0 auto;
+        width: 25%;
+    }
+
+    #profile-detail {
+        flex: 0 0 auto;
+        width: 75%;
+    }
+
+    #profie-container {
+        margin-top: -120px;
+    }
+}
+
 /*Class use in JS*/
 
 .hidden {

--- a/rurusetto/users/templates/users/profile.html
+++ b/rurusetto/users/templates/users/profile.html
@@ -6,11 +6,11 @@
 <div class="px-4 py-4 my-4 text-center align-middle hero"></div>
 
 <div class="container px-4 py-4 my-4 d-grid gap-4">
-  <div class="row" style="margin-top: -11%; width: 1280px;">
-    <div class="col col-2">
-      <img data-aos="zoom-in" data-aos-duration="600" src="{{ profile_object.image.url }}" alt="{{ profile_object.user.username }}" height="160" width="160" class="rounded-circle" >
+  <div class="row profile-container" style="margin-top: -150px;">
+    <div class="col col-2" id="profile-pic">
+      <img data-aos="zoom-in" data-aos-duration="600" src="{{ profile_object.image.url }}" alt="{{ profile_object.user.username }}" width="100%" class="rounded-circle profile-page-pic">
     </div>
-    <div class="col col-10" style="margin-left: -2%;">
+    <div class="col col-10" id="profile-detail">
       <h1 data-aos="fade-up" data-aos-duration="700">{{ profile_object.user.username }}</h1>
       <p data-aos="fade-up" data-aos-duration="750">
           {% for tag in tag_list %}

--- a/rurusetto/wiki/templates/wiki/base.html
+++ b/rurusetto/wiki/templates/wiki/base.html
@@ -45,10 +45,12 @@
     <style>
         .hero {
             background-image: linear-gradient(to bottom, transparent, #2d2d2d), url({{ hero_image }});
+            background-position: top center;
         }
 
         body.light .hero {
             background-image: linear-gradient(to bottom, transparent, #fff), url({{ hero_image_light }});
+            background-position: top center;
         }
 
         {% block css %}{% endblock %}

--- a/rurusetto/wiki/templates/wiki/wiki_page.html
+++ b/rurusetto/wiki/templates/wiki/wiki_page.html
@@ -38,7 +38,7 @@
             </div>
             {% endif %}
             <div class="col-sm-2 hvr-icon-bounce">
-                <p data-aos="fade-up" data-aos-duration="1000"><a class="text-decoration-none text-center" href="{% url "recommend_beatmap" content.slug %}"><i class="fas fa-thumbs-up icon-menu hvr-icon"></i> Recommend beatmaps</a></p>
+                <p data-aos="fade-up" data-aos-duration="1000"><a class="text-decoration-none text-center spacing-hover-short" href="{% url "recommend_beatmap" content.slug %}"><i class="fas fa-thumbs-up icon-menu hvr-icon"></i> Recommend beatmaps</a></p>
             </div>
             <div class="col-sm-2 hvr-icon-bounce">
                 <p data-aos="fade-up" data-aos-duration="1050"><a class="text-decoration-none text-center spacing-hover-short" target="_blank" href="#"><i class="fas fa-download icon-menu hvr-icon"></i> Download</a></p>

--- a/rurusetto/wiki/templates/wiki/wiki_page.html
+++ b/rurusetto/wiki/templates/wiki/wiki_page.html
@@ -38,7 +38,7 @@
             </div>
             {% endif %}
             <div class="col-sm-2 hvr-icon-bounce">
-                <p data-aos="fade-up" data-aos-duration="1000"><a class="text-decoration-none text-center spacing-hover-short" href="{% url "recommend_beatmap" content.slug %}"><i class="fas fa-thumbs-up icon-menu hvr-icon"></i> Recommend beatmaps</a></p>
+                <p data-aos="fade-up" data-aos-duration="1000"><a class="text-decoration-none text-center" href="{% url "recommend_beatmap" content.slug %}"><i class="fas fa-thumbs-up icon-menu hvr-icon"></i> Recommend beatmaps</a></p>
             </div>
             <div class="col-sm-2 hvr-icon-bounce">
                 <p data-aos="fade-up" data-aos-duration="1050"><a class="text-decoration-none text-center spacing-hover-short" target="_blank" href="#"><i class="fas fa-download icon-menu hvr-icon"></i> Download</a></p>


### PR DESCRIPTION
- Because some of the CSS value in profile view make the profile page in mobile is not like expected. This pull request is fixing that problem to make a full support for the mobie view and change the profile picture size to be a little bit bigger.
- Currently I set the main axis of the cover picture position to `center center` and after I tested on a lot of background picture and I think that `top center` is best compatible for the cover image. I will try to change on this and waiting for the review from the users.