### PR TITLE
Fix slutter bug on hover on recommend beatmap button

### DIFF
--- a/rurusetto/wiki/templates/wiki/wiki_page.html
+++ b/rurusetto/wiki/templates/wiki/wiki_page.html
@@ -38,7 +38,7 @@
             </div>
             {% endif %}
             <div class="col-sm-2 hvr-icon-bounce">
-                <p data-aos="fade-up" data-aos-duration="1000"><a class="text-decoration-none text-center spacing-hover-short" href="{% url "recommend_beatmap" content.slug %}"><i class="fas fa-thumbs-up icon-menu hvr-icon"></i> Recommend beatmaps</a></p>
+                <p data-aos="fade-up" data-aos-duration="1000"><a class="text-decoration-none text-center" href="{% url "recommend_beatmap" content.slug %}"><i class="fas fa-thumbs-up icon-menu hvr-icon"></i> Recommend beatmaps</a></p>
             </div>
             <div class="col-sm-2 hvr-icon-bounce">
                 <p data-aos="fade-up" data-aos-duration="1050"><a class="text-decoration-none text-center spacing-hover-short" target="_blank" href="#"><i class="fas fa-download icon-menu hvr-icon"></i> Download</a></p>


### PR DESCRIPTION
When user hover on the blank point after the spacing hover is working it will make the slutter on the text (and when hover, the `recommend beatmap` word is not in one line and I don't want the text to overflow to a new line.) That's why I decided to removed the hover styling from this button.
![CleanShot 2564-09-03 at 20 02 33](https://user-images.githubusercontent.com/68165621/132009483-38499394-796b-4ca9-89c4-84a1eb547f4d.gif)
