### PR TITLE
Make `FileNotFoundError` on login signal handle more properly

### DIFF
--- a/rurusetto/users/signals.py
+++ b/rurusetto/users/signals.py
@@ -34,12 +34,19 @@ def user_update_information_in_allauth(request, user, **kwargs):
         data = SocialAccount.objects.get(user=request.user).extra_data
 
         # If extra data from user detail from osu! API is not None (null in JSON) and it's not default image, can delete
-        if request.user.config.update_profile_every_login and (request.user.profile.image != "default.jpeg") and (
-                data["avatar_url"] is not None):
-            os.remove(f"media/{request.user.profile.image}")
-        if request.user.config.update_profile_every_login and (
-                request.user.profile.cover != "default_cover.png") and (data["cover_url"] is not None):
-            os.remove(f"media/{request.user.profile.cover}")
+        try:
+            if request.user.config.update_profile_every_login and (request.user.profile.image != "default.jpeg") and (
+                    data["avatar_url"] is not None):
+                os.remove(f"media/{request.user.profile.image}")
+        except FileNotFoundError:
+            pass
+
+        try:
+            if request.user.config.update_profile_every_login and (
+                    request.user.profile.cover != "default_cover.png") and (data["cover_url"] is not None):
+                os.remove(f"media/{request.user.profile.cover}")
+        except FileNotFoundError:
+            pass
 
         if data["avatar_url"] is not None:
             avatar_pic = requests.get(data["avatar_url"])


### PR DESCRIPTION
When user turn on the `Update Profile Every Login` function it will always delete and download the new profile picture and cover image.

https://github.com/Rurusetto/rurusetto/blob/12429c0ad286370207ab771329b50bf2b980252c/rurusetto/users/signals.py#L36-L42

But in the edge case if the profile picture or cover image file is disappear the `os` library will raise the `FileNotFoundError` and make the user cannot login or login and get the 500 error page instead. This pull request make the program can handle this situation.