### PR TITLE
Fix beatmap card link incorrectly lead to fatal error

### DIFF
--- a/rurusetto/wiki/function.py
+++ b/rurusetto/wiki/function.py
@@ -118,7 +118,7 @@ def make_recommend_beatmap_view(ruleset_id):
     ruleset = Ruleset.objects.get(id=ruleset_id)
     # Create a list of recommend beatmaps that is recommend by ruleset creator
     try:
-        owner = User.objects.get(id=ruleset.creator)
+        owner = User.objects.get(id=ruleset.owner)
     except User.DoesNotExist:
         owner = None
     recommend_by_owner = []

--- a/rurusetto/wiki/templates/wiki/snippets/beatmap_approval_card.html
+++ b/rurusetto/wiki/templates/wiki/snippets/beatmap_approval_card.html
@@ -91,7 +91,11 @@
             </p>
               <p class="card-text text-muted"><small>mapped by <a href="https://osu.ppy.sh/u/{{ beatmap.0.creator }}" class="text-decoration-none spacing-hover-short">{{ beatmap.0.creator }}</a></small></p>
               <p class="card-text"><small>{{ beatmap.0.comment }}</small></p>
-            <p class="card-text text-muted"><small>Recommend by <a href="{% url "profile" beatmap.1.id %}" class="hvr-picture-bounce text-decoration-none spacing-hover"><img src="{{ beatmap.1.profile.image.url }}" alt="{{ beatmap.1.username }}" width="32" height="32" class="rounded-circle hvr-icon" style="transition: 0.2s"> {{ beatmap.1.username }}</a></small></p>
+          {% if beatmap.1 == None %}
+              <p class="card-text text-muted"><small>Recommend by <img src="{% static 'img/default.jpeg' %}" alt="Deleted User" width="32" height="32" class="rounded-circle hvr-icon"> Deleted User </small></p>
+          {% else %}
+              <p class="card-text text-muted"><small>Recommend by <a href="{% url "profile" beatmap.1.id %}" class="hvr-picture-bounce text-decoration-none spacing-hover"><img src="{{ beatmap.1.profile.image.url }}" alt="{{ beatmap.1.username }}" width="32" height="32" class="rounded-circle hvr-icon" style="transition: 0.2s"> {{ beatmap.1.username }}</a></small></p>
+          {% endif %}
             <p class="card-text"><a class="btn btn-success" href="{% url 'approve_recommend_beatmap' ruleset.slug beatmap.0.id %}" role="button"><i class="fas fa-check color-white"></i> Approve</a> <a class="btn btn-danger" href="{% url 'deny_recommend_beatmap' ruleset.slug beatmap.0.id %}" role="button"><i class="fas fa-times color-white"></i> Deny</a></p>
           </div>
         </div>

--- a/rurusetto/wiki/templates/wiki/snippets/beatmap_card.html
+++ b/rurusetto/wiki/templates/wiki/snippets/beatmap_card.html
@@ -92,7 +92,11 @@
             </p>
               <p class="card-text text-muted"><small>mapped by <a href="https://osu.ppy.sh/u/{{ beatmap.0.creator }}" class="text-decoration-none spacing-hover-short">{{ beatmap.0.creator }}</a></small></p>
               <p class="card-text"><small>{{ beatmap.0.comment }}</small></p>
-            <p class="card-text text-muted"><small>Recommend by <a href="{% url "profile" beatmap.1.id %}" class="hvr-picture-bounce text-decoration-none spacing-hover"><img src="{{ beatmap.1.profile.image.url }}" alt="{{ beatmap.1.username }}" width="32" height="32" class="rounded-circle hvr-icon" style="transition: 0.2s"> {{ beatmap.1.username }}</a></small></p>
+          {% if beatmap.1 == None %}
+              <p class="card-text text-muted"><small>Recommend by <img src="{% static 'img/default.jpeg' %}" alt="Deleted User" width="32" height="32" class="rounded-circle hvr-icon"> Deleted User </small></p>
+          {% else %}
+              <p class="card-text text-muted"><small>Recommend by <a href="{% url "profile" beatmap.1.id %}" class="hvr-picture-bounce text-decoration-none spacing-hover"><img src="{{ beatmap.1.profile.image.url }}" alt="{{ beatmap.1.username }}" width="32" height="32" class="rounded-circle hvr-icon" style="transition: 0.2s"> {{ beatmap.1.username }}</a></small></p>
+          {% endif %}
           <a class="btn btn-rurusetto hvr-bounce-to-bottom" href="osu://b/{{ beatmap.0.beatmap_id }}" role="button"><i class="fas fa-download color-white"></i> osu!direct</a>
           </div>
         </div>


### PR DESCRIPTION
- Fix link on recommend beatmap by ruleset creator part lead to the ruleset creator (A user who create beatmap page) instead of ruleset owner
- Add support on display when the system cannot find the User object who recommend a beatmap in beatmap card