### PR TITLE
Add load static file tag to recommend beatmap approval template

### DIFF
--- a/rurusetto/wiki/templates/wiki/snippets/beatmap_approval_card.html
+++ b/rurusetto/wiki/templates/wiki/snippets/beatmap_approval_card.html
@@ -1,4 +1,5 @@
 {% load convert_star_rating %}
+{% load static %}
 
 <div class="col-sm-6" data-aos="fade-up" data-aos-duration="600" data-aos-once="true">
     <div class="card mb-3" style="max-width: 100%">


### PR DESCRIPTION
Forget to add `load static` to recommend beatmap approval card template