### PR TITLE
Delete star rating from beatmap card

### DIFF
--- a/rurusetto/wiki/templates/wiki/base.html
+++ b/rurusetto/wiki/templates/wiki/base.html
@@ -41,7 +41,6 @@
   <link rel="stylesheet" href="{% static 'css/index.css' %}">
   <link rel="stylesheet" href="{% static 'css/hover.css' %}">
   <link rel="stylesheet" href="{% static 'css/styles.css' %}">
-  <link rel="stylesheet" href="{% static "css/progres-bar.css" %}">
 
     <style>
         .hero {
@@ -196,8 +195,6 @@
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
   <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
-  <script src="https://code.jquery.com/jquery.min.js"></script>
-  <script src="{% static "js/player.js" %}"></script>
   {% block js %}{% endblock %}
   <script src="{% static 'js/custom.min.js' %}"></script>
 

--- a/rurusetto/wiki/templates/wiki/recommend_beatmap.html
+++ b/rurusetto/wiki/templates/wiki/recommend_beatmap.html
@@ -3,6 +3,8 @@
 {% load convert_star_rating %}
 {% block content %}
 
+<link rel="stylesheet" href="{% static "css/progres-bar.css" %}">
+
 <div class="px-4 py-4 my-4 align-middle hero">
     <div class="container align-middle">
         <div class="row">
@@ -81,9 +83,11 @@
 {% endblock content %}
 
 {% block js %}
+  <script src="https://code.jquery.com/jquery.min.js"></script>
+  <script src="{% static "js/player.js" %}"></script>
     <script>
     $(document).ready(function () {
         $('.mediPlayer').mediaPlayer();
     });
-</script>
+    </script>
 {% endblock %}

--- a/rurusetto/wiki/templates/wiki/recommend_beatmap_approval.html
+++ b/rurusetto/wiki/templates/wiki/recommend_beatmap_approval.html
@@ -3,6 +3,8 @@
 {% load convert_star_rating %}
 {% block content %}
 
+<link rel="stylesheet" href="{% static "css/progres-bar.css" %}">
+
 <div class="px-4 py-4 my-4 align-middle hero">
     <div class="container align-middle">
         <div class="row">
@@ -65,9 +67,12 @@
 {% endblock content %}
 
 {% block js %}
+  <script src="https://code.jquery.com/jquery.min.js"></script>
+  <script src="{% static "js/player.js" %}"></script>
     <script>
     $(document).ready(function () {
         $('.mediPlayer').mediaPlayer();
     });
-</script>
+    </script>
 {% endblock %}
+

--- a/rurusetto/wiki/templates/wiki/snippets/beatmap_approval_card.html
+++ b/rurusetto/wiki/templates/wiki/snippets/beatmap_approval_card.html
@@ -14,63 +14,6 @@
             <p class="card-text">by {{ beatmap.0.artist }}</p>
             <p class="card-text text-muted">{{ beatmap.0.source }}</p>
             <p class="card-text">
-              {% if beatmap.0.difficultyrating <= 1.5 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(65, 184, 255); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% elif beatmap.0.difficultyrating > 1.5 and beatmap.0.difficultyrating <= 2.0 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(65, 215, 235); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% elif beatmap.0.difficultyrating > 2.0 and beatmap.0.difficultyrating <= 2.25 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(77, 252, 186); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% elif beatmap.0.difficultyrating > 2.25 and beatmap.0.difficultyrating <= 2.50 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(123, 251, 70); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% elif beatmap.0.difficultyrating > 2.50 and beatmap.0.difficultyrating <= 2.75 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(160, 246, 73); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% elif beatmap.0.difficultyrating > 2.75 and beatmap.0.difficultyrating <= 3.0 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(197, 242, 80); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% elif beatmap.0.difficultyrating > 3.0 and beatmap.0.difficultyrating <= 3.25 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(241, 236, 83); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% elif beatmap.0.difficultyrating > 3.25 and beatmap.0.difficultyrating <= 3.50 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(248, 211, 84); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% elif beatmap.0.difficultyrating > 3.50 and beatmap.0.difficultyrating <= 3.75 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(248, 187, 87); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% elif beatmap.0.difficultyrating > 3.75 and beatmap.0.difficultyrating <= 4.0 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(254, 161, 90); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% elif beatmap.0.difficultyrating > 4.0 and beatmap.0.difficultyrating <= 4.25 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(255, 138, 92); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% elif beatmap.0.difficultyrating > 4.25 and beatmap.0.difficultyrating <= 4.5 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(255, 117, 90); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% elif beatmap.0.difficultyrating > 4.5 and beatmap.0.difficultyrating <= 4.75 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(255, 103, 97); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% elif beatmap.0.difficultyrating > 4.75 and beatmap.0.difficultyrating <= 5 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(255, 95, 95); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% elif beatmap.0.difficultyrating > 5 and beatmap.0.difficultyrating <= 5.25 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(255, 83, 102); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% elif beatmap.0.difficultyrating > 5.25 and beatmap.0.difficultyrating <= 5.5 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(255, 72, 102); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% elif beatmap.0.difficultyrating > 5.5 and beatmap.0.difficultyrating <= 5.75 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(255, 62, 101); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% elif beatmap.0.difficultyrating > 5.75 and beatmap.0.difficultyrating <= 6 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(253, 54, 103); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% elif beatmap.0.difficultyrating > 6 and beatmap.0.difficultyrating <= 6.25 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(209, 64, 132); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% elif beatmap.0.difficultyrating > 6.25 and beatmap.0.difficultyrating <= 6.49 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(166, 73, 157); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% elif beatmap.0.difficultyrating > 6.49 and beatmap.0.difficultyrating <= 6.5 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(166, 73, 157); color: rgb(255, 215, 93);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% elif beatmap.0.difficultyrating > 6.5 and beatmap.0.difficultyrating <= 6.75 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(122, 83, 192); color: rgb(255, 215, 93);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% elif beatmap.0.difficultyrating > 6.75 and beatmap.0.difficultyrating <= 7 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(87, 92, 213); color: rgb(255, 215, 93);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% elif beatmap.0.difficultyrating > 7 and beatmap.0.difficultyrating <= 7.25 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(66, 73, 190); color: rgb(255, 215, 93);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% elif beatmap.0.difficultyrating > 7.25 and beatmap.0.difficultyrating <= 7.5 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(50, 55, 168); color: rgb(255, 215, 93);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% elif beatmap.0.difficultyrating > 7.5 and beatmap.0.difficultyrating <= 7.75 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(36, 39, 150); color: rgb(255, 215, 93);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% elif beatmap.0.difficultyrating > 7.75 and beatmap.0.difficultyrating <= 7.99 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(22, 25, 144); color: rgb(255, 215, 93);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% else %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(0, 0, 0); color: rgb(255, 215, 93);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% endif %}
 
             {% if beatmap.0.approved == "4" %}
                 <span class="badge rounded-pill round-font-bold" style="background-color: rgb(241, 101, 160); color: rgb(51, 58, 61);">LOVED</span>

--- a/rurusetto/wiki/templates/wiki/snippets/beatmap_card.html
+++ b/rurusetto/wiki/templates/wiki/snippets/beatmap_card.html
@@ -15,63 +15,6 @@
             <p class="card-text">by {{ beatmap.0.artist }}</p>
             <p class="card-text text-muted">{{ beatmap.0.source }}</p>
             <p class="card-text">
-              {% if beatmap.0.difficultyrating <= 1.5 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(65, 184, 255); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% elif beatmap.0.difficultyrating > 1.5 and beatmap.0.difficultyrating <= 2.0 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(65, 215, 235); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% elif beatmap.0.difficultyrating > 2.0 and beatmap.0.difficultyrating <= 2.25 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(77, 252, 186); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% elif beatmap.0.difficultyrating > 2.25 and beatmap.0.difficultyrating <= 2.50 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(123, 251, 70); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% elif beatmap.0.difficultyrating > 2.50 and beatmap.0.difficultyrating <= 2.75 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(160, 246, 73); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% elif beatmap.0.difficultyrating > 2.75 and beatmap.0.difficultyrating <= 3.0 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(197, 242, 80); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% elif beatmap.0.difficultyrating > 3.0 and beatmap.0.difficultyrating <= 3.25 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(241, 236, 83); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% elif beatmap.0.difficultyrating > 3.25 and beatmap.0.difficultyrating <= 3.50 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(248, 211, 84); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% elif beatmap.0.difficultyrating > 3.50 and beatmap.0.difficultyrating <= 3.75 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(248, 187, 87); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% elif beatmap.0.difficultyrating > 3.75 and beatmap.0.difficultyrating <= 4.0 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(254, 161, 90); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% elif beatmap.0.difficultyrating > 4.0 and beatmap.0.difficultyrating <= 4.25 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(255, 138, 92); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% elif beatmap.0.difficultyrating > 4.25 and beatmap.0.difficultyrating <= 4.5 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(255, 117, 90); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% elif beatmap.0.difficultyrating > 4.5 and beatmap.0.difficultyrating <= 4.75 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(255, 103, 97); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% elif beatmap.0.difficultyrating > 4.75 and beatmap.0.difficultyrating <= 5 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(255, 95, 95); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% elif beatmap.0.difficultyrating > 5 and beatmap.0.difficultyrating <= 5.25 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(255, 83, 102); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% elif beatmap.0.difficultyrating > 5.25 and beatmap.0.difficultyrating <= 5.5 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(255, 72, 102); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% elif beatmap.0.difficultyrating > 5.5 and beatmap.0.difficultyrating <= 5.75 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(255, 62, 101); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% elif beatmap.0.difficultyrating > 5.75 and beatmap.0.difficultyrating <= 6 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(253, 54, 103); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% elif beatmap.0.difficultyrating > 6 and beatmap.0.difficultyrating <= 6.25 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(209, 64, 132); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% elif beatmap.0.difficultyrating > 6.25 and beatmap.0.difficultyrating <= 6.49 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(166, 73, 157); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% elif beatmap.0.difficultyrating > 6.49 and beatmap.0.difficultyrating <= 6.5 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(166, 73, 157); color: rgb(255, 215, 93);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% elif beatmap.0.difficultyrating > 6.5 and beatmap.0.difficultyrating <= 6.75 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(122, 83, 192); color: rgb(255, 215, 93);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% elif beatmap.0.difficultyrating > 6.75 and beatmap.0.difficultyrating <= 7 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(87, 92, 213); color: rgb(255, 215, 93);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% elif beatmap.0.difficultyrating > 7 and beatmap.0.difficultyrating <= 7.25 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(66, 73, 190); color: rgb(255, 215, 93);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% elif beatmap.0.difficultyrating > 7.25 and beatmap.0.difficultyrating <= 7.5 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(50, 55, 168); color: rgb(255, 215, 93);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% elif beatmap.0.difficultyrating > 7.5 and beatmap.0.difficultyrating <= 7.75 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(36, 39, 150); color: rgb(255, 215, 93);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% elif beatmap.0.difficultyrating > 7.75 and beatmap.0.difficultyrating <= 7.99 %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(22, 25, 144); color: rgb(255, 215, 93);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% else %}
-              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(0, 0, 0); color: rgb(255, 215, 93);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
-              {% endif %}
 
             {% if beatmap.0.approved == "4" %}
                 <span class="badge rounded-pill round-font-bold" style="background-color: rgb(241, 101, 160); color: rgb(51, 58, 61);">LOVED</span>

--- a/rurusetto/wiki/templates/wiki/snippets/star_rating_color.html
+++ b/rurusetto/wiki/templates/wiki/snippets/star_rating_color.html
@@ -1,0 +1,57 @@
+              {% if beatmap.0.difficultyrating <= 1.5 %}
+              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(65, 184, 255); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
+              {% elif beatmap.0.difficultyrating > 1.5 and beatmap.0.difficultyrating <= 2.0 %}
+              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(65, 215, 235); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
+              {% elif beatmap.0.difficultyrating > 2.0 and beatmap.0.difficultyrating <= 2.25 %}
+              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(77, 252, 186); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
+              {% elif beatmap.0.difficultyrating > 2.25 and beatmap.0.difficultyrating <= 2.50 %}
+              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(123, 251, 70); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
+              {% elif beatmap.0.difficultyrating > 2.50 and beatmap.0.difficultyrating <= 2.75 %}
+              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(160, 246, 73); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
+              {% elif beatmap.0.difficultyrating > 2.75 and beatmap.0.difficultyrating <= 3.0 %}
+              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(197, 242, 80); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
+              {% elif beatmap.0.difficultyrating > 3.0 and beatmap.0.difficultyrating <= 3.25 %}
+              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(241, 236, 83); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
+              {% elif beatmap.0.difficultyrating > 3.25 and beatmap.0.difficultyrating <= 3.50 %}
+              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(248, 211, 84); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
+              {% elif beatmap.0.difficultyrating > 3.50 and beatmap.0.difficultyrating <= 3.75 %}
+              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(248, 187, 87); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
+              {% elif beatmap.0.difficultyrating > 3.75 and beatmap.0.difficultyrating <= 4.0 %}
+              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(254, 161, 90); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
+              {% elif beatmap.0.difficultyrating > 4.0 and beatmap.0.difficultyrating <= 4.25 %}
+              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(255, 138, 92); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
+              {% elif beatmap.0.difficultyrating > 4.25 and beatmap.0.difficultyrating <= 4.5 %}
+              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(255, 117, 90); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
+              {% elif beatmap.0.difficultyrating > 4.5 and beatmap.0.difficultyrating <= 4.75 %}
+              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(255, 103, 97); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
+              {% elif beatmap.0.difficultyrating > 4.75 and beatmap.0.difficultyrating <= 5 %}
+              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(255, 95, 95); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
+              {% elif beatmap.0.difficultyrating > 5 and beatmap.0.difficultyrating <= 5.25 %}
+              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(255, 83, 102); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
+              {% elif beatmap.0.difficultyrating > 5.25 and beatmap.0.difficultyrating <= 5.5 %}
+              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(255, 72, 102); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
+              {% elif beatmap.0.difficultyrating > 5.5 and beatmap.0.difficultyrating <= 5.75 %}
+              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(255, 62, 101); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
+              {% elif beatmap.0.difficultyrating > 5.75 and beatmap.0.difficultyrating <= 6 %}
+              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(253, 54, 103); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
+              {% elif beatmap.0.difficultyrating > 6 and beatmap.0.difficultyrating <= 6.25 %}
+              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(209, 64, 132); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
+              {% elif beatmap.0.difficultyrating > 6.25 and beatmap.0.difficultyrating <= 6.49 %}
+              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(166, 73, 157); color: rgb(51, 58, 61);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
+              {% elif beatmap.0.difficultyrating > 6.49 and beatmap.0.difficultyrating <= 6.5 %}
+              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(166, 73, 157); color: rgb(255, 215, 93);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
+              {% elif beatmap.0.difficultyrating > 6.5 and beatmap.0.difficultyrating <= 6.75 %}
+              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(122, 83, 192); color: rgb(255, 215, 93);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
+              {% elif beatmap.0.difficultyrating > 6.75 and beatmap.0.difficultyrating <= 7 %}
+              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(87, 92, 213); color: rgb(255, 215, 93);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
+              {% elif beatmap.0.difficultyrating > 7 and beatmap.0.difficultyrating <= 7.25 %}
+              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(66, 73, 190); color: rgb(255, 215, 93);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
+              {% elif beatmap.0.difficultyrating > 7.25 and beatmap.0.difficultyrating <= 7.5 %}
+              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(50, 55, 168); color: rgb(255, 215, 93);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
+              {% elif beatmap.0.difficultyrating > 7.5 and beatmap.0.difficultyrating <= 7.75 %}
+              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(36, 39, 150); color: rgb(255, 215, 93);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
+              {% elif beatmap.0.difficultyrating > 7.75 and beatmap.0.difficultyrating <= 7.99 %}
+              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(22, 25, 144); color: rgb(255, 215, 93);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
+              {% else %}
+              <span class="badge rounded-pill round-font-bold" style="background-color: rgb(0, 0, 0); color: rgb(255, 215, 93);"><i class="fas fa-star"></i> {{ beatmap.0.difficultyrating | convert_star_rating }}</span>
+              {% endif %}


### PR DESCRIPTION
Because current SR in the current beatmap is from osu! gamemode but each ruleset has own SR calculation so I decided to remove it from the ruleset creator recommendation and move JS on the demo player to only the recommend beatmap page to improve the website performance.