### PR TITLE
Enhance markdown converter

### DIFF
--- a/rurusetto/wiki/templatetags/markdown_converter.py
+++ b/rurusetto/wiki/templatetags/markdown_converter.py
@@ -5,7 +5,8 @@ register = template.Library()
 
 
 def convert_markdown(value):
-    return markdown.markdown(value, extensions=['fenced_code', 'codehilite', 'tables', 'nl2br'])
+    return markdown.markdown(value, extensions=['fenced_code', 'codehilite', 'tables', 'nl2br', 'toc', 'wikilinks', 
+                                                'attr_list'])
 
 
 register.filter('convert_markdown', convert_markdown)

--- a/rurusetto/wiki/templatetags/markdown_converter.py
+++ b/rurusetto/wiki/templatetags/markdown_converter.py
@@ -5,7 +5,7 @@ register = template.Library()
 
 
 def convert_markdown(value):
-    return markdown.markdown(value, extensions=['fenced_code', 'codehilite', 'tables', 'nl2br', 'toc', 'wikilinks', 
+    return markdown.markdown(value, extensions=['fenced_code', 'codehilite', 'tables', 'nl2br', 'toc',
                                                 'attr_list'])
 
 


### PR DESCRIPTION
Add new extension in markdown converter (`toc` and `attr_list`) so it can auto-generate the table of content and add the HTML attribute on wiki page.