### PR TITLE
Add settings to using S3 storage instead of local storage on production

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,7 @@ django-colorfield~=0.4.3
 django-admin-interface~=0.17.1
 python-decouple~=3.5
 python-dateutil~=2.8.2
+boto3~=1.18.58
+django-storages~=1.12
+gunicorn~=20.1.0
+psycopg2-binary~=2.9.1

--- a/rurusetto/rurusetto/custom_storages.py
+++ b/rurusetto/rurusetto/custom_storages.py
@@ -1,11 +1,12 @@
 from storages.backends.s3boto3 import S3Boto3Storage
+from decouple import config
 
 
 class StaticStorage(S3Boto3Storage):
-    bucket_name = '<your_space_name>'
+    bucket_name = config('AWS_STORAGE_BUCKET_NAME', default="your-storage-bucket-name")
     location = 'static'
 
 
 class MediaStorage(S3Boto3Storage):
-    bucket_name = '<your_space_name>'
+    bucket_name = config('AWS_STORAGE_BUCKET_NAME', default="your-storage-bucket-name")
     location = 'media'

--- a/rurusetto/rurusetto/custom_storages.py
+++ b/rurusetto/rurusetto/custom_storages.py
@@ -1,0 +1,11 @@
+from storages.backends.s3boto3 import S3Boto3Storage
+
+
+class StaticStorage(S3Boto3Storage):
+    bucket_name = '<your_space_name>'
+    location = 'static'
+
+
+class MediaStorage(S3Boto3Storage):
+    bucket_name = '<your_space_name>'
+    location = 'media'

--- a/rurusetto/rurusetto/settings.py
+++ b/rurusetto/rurusetto/settings.py
@@ -53,6 +53,7 @@ INSTALLED_APPS = [
     'allauth.socialaccount',
     'allauth.socialaccount.providers.osu',
     'rest_framework',
+    'storages'
 ]
 
 SITE_ID = 1
@@ -95,12 +96,24 @@ WSGI_APPLICATION = 'rurusetto.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/3.2/ref/settings/#databases
 
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': BASE_DIR / 'db.sqlite3',
+if config('DATABASE_DEVELOPMENT', default=True, cast=bool):
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.sqlite3',
+            'NAME': BASE_DIR / 'db.sqlite3',
+        }
     }
-}
+else:
+    DATABASES = {
+        'default': {
+            'ENGINE': f"django.db.backends.{config('DATABASE_TYPE', default='postgresql')}",
+            'NAME': config('DATABASE_NAME', default='peppy-and-his-wangfiles'),
+            'USER': config('DATABASE_USER', default='peppy'),
+            'PASSWORD': config('DATABASE_PASSWORD', default='wang'),
+            'HOST': config('DATABASE_HOST', default='localhost'),
+            'PORT': config('DATABASE_PORT', default=''),
+        }
+    }
 
 AUTHENTICATION_BACKENDS = [
     'django.contrib.auth.backends.ModelBackend',
@@ -141,13 +154,24 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.2/howto/static-files/
 
-STATIC_ROOT = os.path.join(BASE_DIR, 'static/')
-STATIC_URL = '/static/'
+if config('STATIC_LOCAL', default=True, cast=bool):
+    STATIC_ROOT = os.path.join(BASE_DIR, 'static/')
+    STATIC_URL = '/static/'
 
-MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
-MEDIA_URL = '/media/'
+    MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
+    MEDIA_URL = '/media/'
+else:
+    AWS_ACCESS_KEY_ID = config('AWS_ACCESS_KEY_ID', default="your-spaces-access-key")
+    AWS_SECRET_ACCESS_KEY = config('AWS_SECRET_ACCESS_KEY', default="your-spaces-secret-access-key")
+    AWS_STORAGE_BUCKET_NAME = config('AWS_STORAGE_BUCKET_NAME', default="your-storage-bucket-name")
+    AWS_S3_ENDPOINT_URL = config('AWS_S3_ENDPOINT_URL', default="your-endpoint-url")
+    AWS_S3_OBJECT_PARAMETERS = {
+        'CacheControl': 'max-age=86400',
+    }
+    AWS_LOCATION = config('AWS_LOCATION', default="your-spaces-files-folder")
 
-CRISPY_TEMPLATE_PACK = 'bootstrap4'
+    STATIC_URL = 'https://%s/%s/' % (AWS_S3_ENDPOINT_URL, AWS_LOCATION)
+    STATICFILES_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/3.2/ref/settings/#default-auto-field
@@ -162,6 +186,10 @@ ACCOUNT_EMAIL_VERIFICATION = 'none'
 # More enum configuration on website
 
 MAX_PROFILE_PICTURE_SIZE = 5242880
+
+# Django crispy forms settings
+
+CRISPY_TEMPLATE_PACK = 'bootstrap4'
 
 # API key and API configuration
 

--- a/rurusetto/rurusetto/settings.py
+++ b/rurusetto/rurusetto/settings.py
@@ -165,13 +165,27 @@ else:
     AWS_SECRET_ACCESS_KEY = config('AWS_SECRET_ACCESS_KEY', default="your-spaces-secret-access-key")
     AWS_STORAGE_BUCKET_NAME = config('AWS_STORAGE_BUCKET_NAME', default="your-storage-bucket-name")
     AWS_S3_ENDPOINT_URL = config('AWS_S3_ENDPOINT_URL', default="your-endpoint-url")
+    AWS_S3_CUSTOM_DOMAIN = config('AWS_S3_CUSTOM_DOMAIN', default="your_custom_domain_url")
     AWS_S3_OBJECT_PARAMETERS = {
         'CacheControl': 'max-age=86400',
     }
     AWS_LOCATION = config('AWS_LOCATION', default="your-spaces-files-folder")
 
-    STATIC_URL = 'https://%s/%s/' % (AWS_S3_ENDPOINT_URL, AWS_LOCATION)
-    STATICFILES_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
+    STATICFILES_STORAGE = 'custom_storages.StaticStorage'
+    DEFAULT_FILE_STORAGE = 'custom_storages.MediaStorage'
+
+    if AWS_S3_CUSTOM_DOMAIN == "":
+        STATIC_URL = '{}/{}/'.format(AWS_S3_CUSTOM_DOMAIN, 'static')
+        STATIC_ROOT = 'static/'
+
+        MEDIA_URL = '{}/{}/'.format(AWS_S3_CUSTOM_DOMAIN, 'media')
+        MEDIA_ROOT = 'media/'
+    else:
+        STATIC_URL = '{}/{}/'.format(AWS_S3_ENDPOINT_URL, 'static')
+        STATIC_ROOT = 'static/'
+
+        MEDIA_URL = '{}/{}/'.format(AWS_S3_ENDPOINT_URL, 'media')
+        MEDIA_ROOT = 'media/'
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/3.2/ref/settings/#default-auto-field


### PR DESCRIPTION
Add settings to using a storage like S3 or DigitalOcean Space to store some assets in an online space instead of on the server itself.