### PR TITLE
Fix patreon and unknown source link variable is incorrect rendered

### DIFF
--- a/rurusetto/wiki/templates/wiki/status.html
+++ b/rurusetto/wiki/templates/wiki/status.html
@@ -137,7 +137,7 @@
             <p><i class="fas fa-exclamation-circle"></i> This function is not support in rulesets that is from Patreon. You can go to rulesets creator's Patreon at <code>Get from Patreon</code>!</p>
         </div>
         <div class="col-4">
-            <p><a class="text-decoration-none text-center spacing-hover-short hvr-icon-bounce" href="{{ ruleset.2 }}"><i class="fab fa-patreon icon-menu hvr-icon"></i> Get from Patreon</a></p>
+            <p><a class="text-decoration-none text-center spacing-hover-short hvr-icon-bounce" href="{{ ruleset.2.0 }}"><i class="fab fa-patreon icon-menu hvr-icon"></i> Get from Patreon</a></p>
             <p><a class="text-decoration-none text-center spacing-hover-short hvr-icon-bounce" href="{% url 'wiki' ruleset.0.slug %}"><i class="fas fa-location-arrow icon-menu hvr-icon"></i> Go to rulesets wiki page</a></p>
         </div>
     </div>
@@ -162,7 +162,7 @@
             <p><i class="fas fa-exclamation-circle"></i> Rūrusetto-chan don't know this link's type so you can download the ruleset from its source. </p>
         </div>
         <div class="col-4">
-            <p><a class="text-decoration-none text-center spacing-hover-short hvr-icon-bounce" href="{{ ruleset.2 }}"><i class="fas fa-external-link-square-alt icon-menu hvr-icon"></i> Ruleset Source</a></p>
+            <p><a class="text-decoration-none text-center spacing-hover-short hvr-icon-bounce" href="{{ ruleset.2.0 }}"><i class="fas fa-external-link-square-alt icon-menu hvr-icon"></i> Ruleset Source</a></p>
             <p><a class="text-decoration-none text-center spacing-hover-short hvr-icon-bounce" href="{% url 'wiki' ruleset.0.slug %}"><i class="fas fa-location-arrow icon-menu hvr-icon"></i> Go to rulesets wiki page</a></p>
         </div>
     </div>


### PR DESCRIPTION
Now it's render as only the link instead of the entire list from database.