### PR TITLE
Change the picture preview from link to image

### DIFF
--- a/rurusetto/users/templates/users/settings.html
+++ b/rurusetto/users/templates/users/settings.html
@@ -97,7 +97,7 @@
                  <div class="mb-3 row">
                     <label for="id_image" class="col-sm-2 col-form-label form-label">Profile picture:</label>
                     <div class="col-sm-10">
-                      <div class="raleway-font form-current">Current Profile : <a href="{{ profile_form.image.value.url }}">{{ profile_form.image.value }}</a></div>
+                      <div class="raleway-font form-current">Current Profile : <img src="{{ profile_form.image.value.url }}" alt="Current Profile Image" style="width:100%; height:auto; max-width: 150px;"></div>
                       <input type="file" name="image" accept="image/*" id="id_image" class="form-control">
                         <p class="form-error raleway-font">{{ profile_form.image.errors }}</p>
                     </div>
@@ -107,7 +107,7 @@
                  <div class="mb-3 row">
                     <label for="id_cover" class="col-sm-2 col-form-label form-label">Profile page cover image:</label>
                     <div class="col-sm-10">
-                      <div class="raleway-font form-current">Current Cover : <a href="{{ profile_form.cover.value.url }}">{{ profile_form.cover.value }}</a></div>
+                      <div class="raleway-font form-current">Current Cover : <img src="{{ profile_form.cover.value.url }}" alt="Current Cover Image" style="width:100%; height:auto; max-width: 500px;"></div>
                       <input type="file" name="cover" accept="image/*" id="id_cover" class="form-control">
                         <p class="form-error raleway-font">{{ profile_form.cover.errors }}</p>
                     </div>
@@ -117,7 +117,7 @@
                  <div class="mb-3 row">
                     <label for="id_cover_light" class="col-sm-2 col-form-label form-label">Profile page cover image in light mode:</label>
                     <div class="col-sm-10">
-                      <div class="raleway-font form-current">Current Light Mode Cover : <a href="{{ profile_form.cover_light.value.url }}">{{ profile_form.cover_light.value }}</a></div>
+                      <div class="raleway-font form-current">Current Light Mode Cover : <img src="{{ profile_form.cover_light.value.url }}" alt="Current Light Mode Cover" style="width:100%; height:auto; max-width: 500px;"></div>
                       <input type="file" name="cover_light" accept="image/*" id="id_cover_light" class="form-control">
                         <p class="form-error raleway-font">{{ profile_form.cover_light.errors }}</p>
                     </div>


### PR DESCRIPTION
This change make user can preview the current picture setting easier instead of the URL
![image](https://user-images.githubusercontent.com/68165621/146656021-c572dab5-cc48-40ba-969d-b89be715c714.png)
