### PR TITLE
Add compatibility to redirect to the new URL path from the old website path

### DIFF
--- a/rurusetto/wiki/tests.py
+++ b/rurusetto/wiki/tests.py
@@ -93,3 +93,19 @@ class RulesetModelTest(TestCase):
         self.assertEqual(blank_ruleset.source, '')
         self.assertEqual(blank_ruleset.last_edited_by, '0')
         self.assertEqual(blank_ruleset.verified, False)
+
+
+class RedirectFromOldLinkTest(TestCase):
+    """Test for fallback URL view that will be redirect to the new URL view"""
+
+    def test_is_redirect_on_valid_rulesets(self):
+        """Test that the redirect view is redirect the link on the valid rulesets"""
+        Ruleset.objects.create(name='dummy', slug='dummy')
+        self.assertTrue(Ruleset.objects.filter(slug='dummy'))
+        response = self.client.get('/pages/dummy')
+        self.assertRedirects(response, '/rulesets/dummy')
+
+    def test_is_404_on_not_valid_rulesets(self):
+        """Test that the view will redirect to 404 id the query rulesets is not found"""
+        response = self.client.get('/pages/peeppy')
+        self.assertEqual(response.status_code, 404)

--- a/rurusetto/wiki/urls.py
+++ b/rurusetto/wiki/urls.py
@@ -27,5 +27,7 @@ urlpatterns = [
     path('action/update/action_log/<int:log_id>', views.check_action_log, name='check_action_log'),
     # URL path for API
     path('api/rulesets', views.ruleset_list),
-    path('api/rulesets/<slug:slug>', views.ruleset_detail)
+    path('api/rulesets/<slug:slug>', views.ruleset_detail),
+    # Fallback URL path for redirect user who use old website link to the new website path
+    path('pages/<slug:slug>', views.redirect_from_old_link, name='redirect_from_old_link')
 ]

--- a/rurusetto/wiki/views.py
+++ b/rurusetto/wiki/views.py
@@ -814,6 +814,24 @@ def archived_rulesets(request):
     return render(request, 'wiki/archived_rulesets.html', context)
 
 
+# Fallback view for redirect user from old website URL to the new website's path
+
+
+def redirect_from_old_link(request, slug):
+    """
+    View for redirect the user that use the old link path (pages/<RulesetsName>) to the new path
+    that we currently use (rulesets/<RulesetsName>)
+
+    :param request: WSGI request from user
+    :param slug: Ruleset slug (slug in Ruleset model)
+    :return: Redirect the user to the cuurent wiki_page's link
+    """
+    if Ruleset.objects.filter(slug=slug).exists():
+        return redirect('wiki', slug=slug)
+    else:
+        return HttpResponse(status=404)
+
+
 # Views for API
 
 


### PR DESCRIPTION
Close #139 

Since before big update we use the path to rulesets as `pages/<RulesetsName>` and it will redirect to 404 if user use this path these day so I add a compatibility to redirect from `pages/<RulesetsName>` to the new path (`rulesets/<RulesetsName>`) with a test.