### PR TITLE
Add `archive` parameter to API

### DIFF
--- a/rurusetto/api/serializers.py
+++ b/rurusetto/api/serializers.py
@@ -34,7 +34,7 @@ class RulesetListingSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Ruleset
-        fields = ['id', 'name', 'slug', 'description', 'icon', 'light_icon', 'owner_detail', 'verified',
+        fields = ['id', 'name', 'slug', 'description', 'icon', 'light_icon', 'owner_detail', 'verified', 'archive',
                   'direct_download_link', 'can_download', 'status']
 
     def get_owner_detail(self, obj):


### PR DESCRIPTION
Add `archive` parameter in `Ruleset` database model that's show if the ruleset is archived or not longer maintain by rulesets owner.

# Connect work
- [x] Add this parameter to API docs (https://github.com/Rurusetto/docs/pull/3)