### PR TITLE
Change latest rulesets list in homepage to show normal listing

### DIFF
--- a/rurusetto/wiki/templates/wiki/home.html
+++ b/rurusetto/wiki/templates/wiki/home.html
@@ -50,13 +50,9 @@
     {% endif %}
 
     <div class="container">
-        <div class="row mb-3">
-          <h1>Latest rulesets</h1>
-        </div>
         <div class="row text-center">
-          {% for detail in latest_add_rulesets %}
+          {% for detail in rulesets %}
           <div class="col-lg-4">
-
               {% if user.config.theme == 'light' %}
               <img src="{{ detail.0.light_icon.url }}" alt="{{ detail.0.name }}" width="140px" height="140px" class="rounded-circle">
               {% else %}

--- a/rurusetto/wiki/views.py
+++ b/rurusetto/wiki/views.py
@@ -31,12 +31,6 @@ def home(request):
     """
     hero_image = 'img/home-cover-night.png'
     hero_image_light = 'img/home-cover-light.jpeg'
-    latest_add_rulesets = []
-    for i in range(3):
-        try:
-            latest_add_rulesets.append(Ruleset.objects.filter(hidden=False).order_by('-created_at')[i])
-        except:
-            continue
 
     context = {
         'title': 'home',
@@ -45,7 +39,7 @@ def home(request):
         'opengraph_description': 'A page that contain all osu! ruleset',
         'opengraph_url': resolve_url('home'),
         # Use make_listing_view function to get the User object from database and pass to template
-        'latest_add_rulesets': make_listing_view(latest_add_rulesets),
+        'rulesets': make_listing_view(Ruleset.objects.filter(hidden=False, archive=False).order_by('name')),
         'test_server': TEST_SERVER,
         'is_in_debug': DEBUG
     }


### PR DESCRIPTION
At first we design the homepage as the personalize page for each user but since it's much out of scope so let's change it to the normal listing as @LumpBloom7 recommendation.