### PR TITLE
Change rulesets listing sort behavior to case insensitive

### DIFF
--- a/rurusetto/wiki/function.py
+++ b/rurusetto/wiki/function.py
@@ -1,4 +1,6 @@
 from django.contrib.auth.models import User
+from django.db.models.functions import Lower
+
 from .models import Ruleset, RecommendBeatmap, RulesetStatus
 
 
@@ -177,7 +179,7 @@ def make_status_view():
     :return: The list of data needed to render in status page template.
     """
     show_ruleset = []
-    for ruleset in Ruleset.objects.filter(hidden=False).order_by('name'):
+    for ruleset in Ruleset.objects.filter(hidden=False).order_by(Lower('name')):
         if source_link_type(ruleset.source) == 'patreon':
             # Patreon source is just need to go to Patreon owner page.
             show_ruleset.append([ruleset, 'patreon', [ruleset.source, RulesetStatus.objects.get(ruleset=ruleset)]])

--- a/rurusetto/wiki/views.py
+++ b/rurusetto/wiki/views.py
@@ -1,5 +1,6 @@
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
+from django.db.models.functions import Lower
 from django.shortcuts import render, redirect, get_object_or_404, resolve_url
 from django.templatetags.static import static
 from django.utils import timezone
@@ -39,7 +40,7 @@ def home(request):
         'opengraph_description': 'A page that contain all osu! ruleset',
         'opengraph_url': resolve_url('home'),
         # Use make_listing_view function to get the User object from database and pass to template
-        'rulesets': make_listing_view(Ruleset.objects.filter(hidden=False, archive=False).order_by('name')),
+        'rulesets': make_listing_view(Ruleset.objects.filter(hidden=False, archive=False).order_by(Lower('name'))),
         'test_server': TEST_SERVER,
         'is_in_debug': DEBUG
     }
@@ -78,8 +79,8 @@ def listing(request):
     hero_image_light = 'img/listing-cover-light.png'
 
     context = {
-        'hidden_rulesets': make_listing_view(Ruleset.objects.filter(hidden=True, owner=str(request.user.id)).order_by('name')),
-        'rulesets': make_listing_view(Ruleset.objects.filter(hidden=False, archive=False).order_by('name')),
+        'hidden_rulesets': make_listing_view(Ruleset.objects.filter(hidden=True, owner=str(request.user.id)).order_by(Lower('name'))),
+        'rulesets': make_listing_view(Ruleset.objects.filter(hidden=False, archive=False).order_by(Lower('name'))),
         'title': 'listing',
         'hero_image': static(hero_image),
         'hero_image_light': static(hero_image_light),
@@ -790,7 +791,7 @@ def archived_rulesets(request):
     hero_image = "img/archived-rulesets-cover-night.jpg"
     hero_image_light = "img/archived-rulesets-cover-light.png"
     context = {
-        'rulesets': make_listing_view(Ruleset.objects.filter(archive=True, hidden=False).order_by('name')),
+        'rulesets': make_listing_view(Ruleset.objects.filter(archive=True, hidden=False).order_by(Lower('name'))),
         'title': 'archived rulesets',
         'hero_image': static(hero_image),
         'hero_image_light': static(hero_image_light),


### PR DESCRIPTION
At first the sort behavior using Django's sort that's mean the object that use capital letter will come first. This PR change the behavior of how it sort by just lower it first before let it sort.

```python
# Before
'rulesets': make_listing_view(Ruleset.objects.filter(hidden=False, archive=False).order_by('name')),
# After
'rulesets': make_listing_view(Ruleset.objects.filter(hidden=False, archive=False).order_by(Lower('name'))),
```