### PR TITLE
Add `tags` and `created_rulesets` to profile API

### DIFF
--- a/rurusetto/api/serializers.py
+++ b/rurusetto/api/serializers.py
@@ -33,6 +33,24 @@ class RulesetListingSerializer(serializers.ModelSerializer):
             return {}
 
 
+class RulesetProfileSerializer(serializers.ModelSerializer):
+    """
+    Serializer for use in profile serializer that don't need owner detail.
+    """
+    status = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Ruleset
+        fields = ['id', 'name', 'slug', 'description', 'icon', 'light_icon', 'verified', 'archive',
+                  'direct_download_link', 'can_download', 'status']
+
+    def get_status(self, obj):
+        try:
+            return StatusDetailSerializer(RulesetStatus.objects.get(ruleset=obj)).data
+        except RulesetStatus.DoesNotExist:
+            return {}
+
+
 # Serializer for rulesets detail
 
 
@@ -202,7 +220,7 @@ class UserFullSerializer(serializers.ModelSerializer):
 
     def get_created_rulesets(self, obj):
         try:
-            return RulesetListingSerializer(Ruleset.objects.filter(owner=str(obj.id)), many=True).data
+            return RulesetProfileSerializer(Ruleset.objects.filter(owner=str(obj.id)), many=True).data
         except Ruleset.DoesNotExist:
             return []
 

--- a/rurusetto/api/serializers.py
+++ b/rurusetto/api/serializers.py
@@ -189,9 +189,14 @@ class UserFullSerializer(serializers.ModelSerializer):
         if obj.tag == '':
             return []
         tags_list = obj.tag.split(',')
-        tags_list = [Tag.objects.get(id=int(tag)) for tag in tags_list]
+        tags_list_converted = []
+        for tag in tags_list:
+            try:
+                tags_list_converted.append(Tag.objects.get(id=int(tag)))
+            except Tag.DoesNotExist:
+                pass
         try:
-            return TagSerializer(tags_list, many=True).data
+            return TagSerializer(tags_list_converted, many=True).data
         except Tag.DoesNotExist:
             return []
 


### PR DESCRIPTION
Add `tags` and `created_rulesets` to the old profile API since these 2 fields is available on the profile page but not get 
 implemented on.