### PR TITLE
Fix URL is not support trailing slash fallback

### DIFF
--- a/rurusetto/rurusetto/settings.py
+++ b/rurusetto/rurusetto/settings.py
@@ -201,6 +201,10 @@ MAX_PROFILE_PICTURE_SIZE = 5242880
 
 CRISPY_TEMPLATE_PACK = 'bootstrap4'
 
+# Add support for trailing URL slash support
+
+APPEND_SLASH = False
+
 # API key and API configuration
 
 OSU_OAUTH_CLIENT_ID = config('OSU_OAUTH_CLIENT_ID', default="")

--- a/rurusetto/rurusetto/settings.py
+++ b/rurusetto/rurusetto/settings.py
@@ -203,7 +203,7 @@ CRISPY_TEMPLATE_PACK = 'bootstrap4'
 
 # Add support for trailing URL slash support
 
-APPEND_SLASH = False
+APPEND_SLASH = True
 
 # API key and API configuration
 

--- a/rurusetto/wiki/urls.py
+++ b/rurusetto/wiki/urls.py
@@ -3,10 +3,10 @@ from . import views
 
 urlpatterns = [
     path('', views.home, name='home'),
-    path('rulesets/', views.listing, name='listing'),
-    path('archived/', views.archived_rulesets, name='archived_rulesets'),
-    path('new/', views.create_ruleset, name='create_ruleset'),
-    path('changelog/', views.changelog, name='changelog'),
+    path('rulesets', views.listing, name='listing'),
+    path('archived', views.archived_rulesets, name='archived_rulesets'),
+    path('new', views.create_ruleset, name='create_ruleset'),
+    path('changelog', views.changelog, name='changelog'),
     path('rulesets/<slug:slug>', views.wiki_page, name='wiki'),
     path('rulesets/<slug:slug>/beatmaps', views.recommend_beatmap, name='recommend_beatmap'),
     path('rulesets/<slug:slug>/edit', views.edit_ruleset_wiki, name='edit_wiki'),


### PR DESCRIPTION
Close #316 

From [Django docs](https://docs.djangoproject.com/en/4.0/ref/settings/#append-slash) that I remember the `APPEND_SLASH` default value is True but this is not work so I add it to the settings and also remove some URL path that already have the slash at the end.