### PR TITLE
Allow maintainer to access recommend beatmap approval page

### DIFF
--- a/rurusetto/wiki/templates/wiki/recommend_beatmap.html
+++ b/rurusetto/wiki/templates/wiki/recommend_beatmap.html
@@ -21,7 +21,7 @@
         <div class="col-sm-2">
             <p data-aos="fade-up" data-aos-duration="700"><a class="text-decoration-none text-center spacing-hover-short hvr-icon-bounce" href="{% url "wiki" ruleset.slug %}"><i class="fas fa-chevron-circle-left icon-menu hvr-icon"></i> {% trans "back_to_main_page" %}</a></p>
         </div>
-        {% if user.is_authenticated and is_owner %}
+        {% if user.is_authenticated and is_owner and user.is_staff %}
             <div class="col-sm-3">
                 <p data-aos="fade-up" data-aos-duration="700"><a class="text-decoration-none text-center spacing-hover-short hvr-icon-bounce" href="{% url 'add_recommend_beatmap' ruleset.slug %}"><i class="fas fa-plus icon-menu hvr-icon"></i> {% trans "add_a_recommend_beatmap" %}</a></p>
             </div>

--- a/rurusetto/wiki/views.py
+++ b/rurusetto/wiki/views.py
@@ -579,7 +579,7 @@ def recommend_beatmap_approval(request, rulesets_slug):
     ruleset = get_object_or_404(Ruleset, slug=rulesets_slug)
     hero_image = ruleset.recommend_beatmap_cover.url
     hero_image_light = ruleset.recommend_beatmap_cover.url
-    if request.user.id == int(ruleset.owner):
+    if request.user.id == int(ruleset.owner) or request.user.is_staff:
         beatmap_list = make_beatmap_aapproval_view(ruleset.id)
         if len(beatmap_list) == 0:
             no_beatmap = True
@@ -618,7 +618,7 @@ def approve_recommend_beatmap(request, rulesets_slug, beatmap_id):
     """
     beatmap = RecommendBeatmap.objects.get(id=beatmap_id)
     ruleset = Ruleset.objects.get(id=beatmap.ruleset_id)
-    if request.user.id == int(ruleset.owner):
+    if request.user.id == int(ruleset.owner) or request.user.is_staff:
         if beatmap.owner_seen:
             messages.error(request, f"You already qualified this beatmap!")
         else:
@@ -645,7 +645,7 @@ def deny_recommend_beatmap(request, rulesets_slug, beatmap_id):
     """
     beatmap = RecommendBeatmap.objects.get(id=beatmap_id)
     ruleset = Ruleset.objects.get(id=beatmap.ruleset_id)
-    if request.user.id == int(ruleset.owner):
+    if request.user.id == int(ruleset.owner) or request.user.is_staff:
         if beatmap.owner_seen:
             messages.error(request, f"You already qualified this beatmap!")
         else:


### PR DESCRIPTION
Since we want to try on let maintainer can access to the recommend beatmap approval page (that currently only owner can access this page). If it's not work we will revert it back