### PR TITLE
Add support for Datadog monitoring

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,5 @@ django-storages~=1.12
 gunicorn~=20.1.0
 psycopg2-binary~=2.9.3
 sentry-sdk~=1.5.11
+ddtrace~=1.1.2
+setproctitle~=1.2.3

--- a/rurusetto/rurusetto/settings.py
+++ b/rurusetto/rurusetto/settings.py
@@ -57,7 +57,8 @@ INSTALLED_APPS = [
     'allauth.socialaccount',
     'allauth.socialaccount.providers.osu',
     'rest_framework',
-    'storages'
+    'storages',
+    'ddtrace.contrib.django',
 ]
 
 SITE_ID = 1


### PR DESCRIPTION
Currently I add Datadog as a tool for monitoring the server. All element from infra side is already implemented excepted inside Django process.