### PR TITLE
Make image size in accordian body always inside accordian

### DIFF
--- a/rurusetto/users/static/css/index.css
+++ b/rurusetto/users/static/css/index.css
@@ -523,6 +523,10 @@ button.accordion-button:focus {
     filter: invert(0.4);
 }
 
+.accordion-body img {
+    width: 100%!important;
+}
+
 .editormd-preview p,
 .editormd-preview label,
 .editormd-preview li {


### PR DESCRIPTION
This fix thing that [the latest release of tau's changelog](https://github.com/taulazer/tau/releases/tag/2022.516.0) has made

| Before | After |
|---------|---------|
| ![Before](https://user-images.githubusercontent.com/68165621/168583620-910702a6-16f6-428e-9e1a-b9686ccfad23.png) | ![After](https://user-images.githubusercontent.com/68165621/168583747-c15bc8e4-d085-4be7-82ba-f367c66f21ce.png) |
