### PR TITLE
Remove old python from workflow

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.9, 3.11]
+        python-version: [3.11]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Remove python 3.9 from Django test workflow